### PR TITLE
Added TUIST_IS_ROOT_MANIFEST environment variable for manifest files

### DIFF
--- a/Sources/TuistKit/Services/DumpService.swift
+++ b/Sources/TuistKit/Services/DumpService.swift
@@ -30,7 +30,7 @@ final class DumpService {
         let encoded: Encodable
         switch manifest {
         case .project:
-            encoded = try manifestLoader.loadProject(at: projectPath)
+            encoded = try manifestLoader.loadProject(at: projectPath, rootPath: nil)
         case .workspace:
             encoded = try manifestLoader.loadWorkspace(at: projectPath)
         case .config:

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -66,9 +66,9 @@ public class CachedManifestLoader: ManifestLoading {
         }
     }
 
-    public func loadProject(at path: AbsolutePath) throws -> Project {
+    public func loadProject(at path: AbsolutePath, rootPath: AbsolutePath? = nil) throws -> Project {
         try load(manifest: .project, at: path) {
-            try manifestLoader.loadProject(at: path)
+            try manifestLoader.loadProject(at: path, rootPath: rootPath)
         }
     }
 

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -51,7 +51,7 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
             manifestLoader.manifests(at: $0).contains(.project)
         }
 
-        let projects = try loadProjects(paths: projectPaths)
+        let projects = try loadProjects(rootPath: path, paths: projectPaths)
         let workspace: ProjectDescription.Workspace
         if let loadedWorkspace = loadedWorkspace {
             workspace = loadedWorkspace
@@ -69,14 +69,14 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
 
     // MARK: - Private
 
-    private func loadProjects(paths: [AbsolutePath]) throws -> LoadedProjects {
+    private func loadProjects(rootPath: AbsolutePath, paths: [AbsolutePath]) throws -> LoadedProjects {
         var cache = [AbsolutePath: ProjectDescription.Project]()
 
         var paths = Set(paths)
         while !paths.isEmpty {
             paths.subtract(cache.keys)
             let projects = try Array(paths).map(context: ExecutionContext.concurrent) {
-                try manifestLoader.loadProject(at: $0)
+                return try manifestLoader.loadProject(at: $0, rootPath: rootPath)
             }
             var newDependenciesPaths = Set<AbsolutePath>()
             try zip(paths, projects).forEach { path, project in


### PR DESCRIPTION
…es to know if it's being generated from local folder or being integrated as .project() dependency

Added new rootPath parameter to ManifestLoader loadManifest() methods

Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

> Describe here the purpose of your PR.

Example App:
https://github.com/Buju77/TuistRootManifestFileExample

Integrated Pod Dependency:
https://github.com/Buju77/TuistExampleLoggingLibrary

Simplifier Tuist Plugin:
https://github.com/Buju77/playground-tuist-simplifier/tree/0.0.5

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
